### PR TITLE
feat: add OR syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,12 @@ jobs:
             --env grep=-@tag1 \
             --expect ./expects/invert-tag1.json
 
+      - name: Run tests with hello OR @tag1 🧪
+        run: |
+          npx cypress-expect \
+            --env grep='hello @tag1' \
+            --expect ./expects/hello-or-tag1.json
+
       - name: Semantic Release 🚀
         uses: cycjimmy/semantic-release-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ You can skip running the tests with specific tag using the invert option: prefix
 --env grep=-@slow
 ```
 
+### OR tags
+
+You can run tests that match one tag or another using spaces. Make sure to quote the grep string!
+
+```
+# run tests with tags "@slow" or "@critical" in their names
+--env grep='@slow @critical'
+```
+
 ## Examples
 
 - [cypress-grep-example](https://github.com/bahmutov/cypress-grep-example)

--- a/cypress/integration/unit.js
+++ b/cypress/integration/unit.js
@@ -11,9 +11,13 @@ describe('utils', () => {
     it('creates objects from the grep string', () => {
       const parsed = parseGrep('@tag1+@tag2+@tag3')
       expect(parsed).to.deep.equal([
-        { tag: '@tag1', invert: false },
-        { tag: '@tag2', invert: false },
-        { tag: '@tag3', invert: false },
+        // single OR part
+        [
+          // with 3 AND parts
+          { tag: '@tag1', invert: false },
+          { tag: '@tag2', invert: false },
+          { tag: '@tag3', invert: false },
+        ],
       ])
     })
   })
@@ -51,6 +55,23 @@ describe('utils', () => {
       expect(t('has only @tag1 in the name')).to.be.false
       expect(t('has only @tag2 in the name')).to.be.false
       expect(t('has @tag1 and @tag2 in the name')).to.be.true
+    })
+
+    it('with OR option', () => {
+      const t = checkName('@tag1 @tag2')
+      expect(t('no tag1 here')).to.be.false
+      expect(t('has only @tag1 in the name')).to.be.true
+      expect(t('has only @tag2 in the name')).to.be.true
+      expect(t('has @tag1 and @tag2 in the name')).to.be.true
+    })
+
+    it('OR with AND option', () => {
+      const t = checkName('@tag1 @tag2+@tag3')
+      expect(t('no tag1 here')).to.be.false
+      expect(t('has only @tag1 in the name')).to.be.true
+      expect(t('has only @tag2 in the name')).to.be.false
+      expect(t('has only @tag2 in the name and also @tag3')).to.be.true
+      expect(t('has @tag1 and @tag2 and @tag3 in the name')).to.be.true
     })
   })
 })

--- a/expects/hello-or-tag1.json
+++ b/expects/hello-or-tag1.json
@@ -1,0 +1,7 @@
+{
+  "hello world": "passed",
+  "works": "pending",
+  "works 2 @tag1": "passed",
+  "works 2 @tag1 @tag2": "passed",
+  "works @tag2": "pending"
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,28 +1,37 @@
 function parseGrep(s) {
-  const parsed = s.split('+').map((tag) => {
-    if (tag.startsWith('-')) {
-      return {
-        tag: tag.slice(1),
-        invert: true,
+  // top level split - using space, each part is OR
+  const ORS = s.split(' ').map((part) => {
+    // now every part is an AND
+    const parsed = part.split('+').map((tag) => {
+      if (tag.startsWith('-')) {
+        return {
+          tag: tag.slice(1),
+          invert: true,
+        }
       }
-    }
 
-    return {
-      tag,
-      invert: false,
-    }
+      return {
+        tag,
+        invert: false,
+      }
+    })
+
+    return parsed
   })
 
-  return parsed
+  return ORS
 }
 
 function shouldTestRun(parsedGrep, testName) {
-  return parsedGrep.every((p) => {
-    if (p.invert) {
-      return !testName.includes(p.tag)
-    }
+  // top levels are OR
+  return parsedGrep.some((orPart) => {
+    return orPart.every((p) => {
+      if (p.invert) {
+        return !testName.includes(p.tag)
+      }
 
-    return testName.includes(p.tag)
+      return testName.includes(p.tag)
+    })
   })
 }
 


### PR DESCRIPTION
closes #6

You can run tests that match one tag or another using spaces. Make sure to quote the grep string!

```
# run tests with tags "@slow" or "@critical" in their names
--env grep='@slow @critical'
```