### PR TITLE
feat: support tags in the test config object

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             --env grep=pending \
             --expect expects/pending.json
 
-      # tests can use custom config object argument
+      # tests do not break the custom test config object as argument
       - name: Run e2e tests with config object with grep 🧪
         run: |
           npx cypress-expect \
@@ -90,6 +90,15 @@ jobs:
           npx cypress-expect \
             --env grep='hello @tag1' \
             --expect ./expects/hello-or-tag1.json
+
+      # you can pass test tags in the config object
+      - name: Run e2e tests with tags in the config 🧪
+        run: |
+          npx cypress-expect \
+            --spec cypress/integration/config-tags-spec.js \
+            --config testFiles="config-tags-spec.js" \
+            --env grep=config \
+            --expect expects/config-tags-spec.json
 
       - name: Semantic Release 🚀
         uses: cycjimmy/semantic-release-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Run unit tests 🧪
         run: |
-          npx cypress run --config testFiles="**/*.js"
+          npx cypress run --config testFiles="**/unit.js"
 
       - name: Run e2e tests 🧪
         run: |

--- a/README.md
+++ b/README.md
@@ -109,6 +109,22 @@ You can run tests that match one tag or another using spaces. Make sure to quote
 --env grep='@slow @critical'
 ```
 
+## Tags in the test config object
+
+Cypress tests can have their own [test config object](https://on.cypress.io/configuration#Test-Configuration), and when using this plugin you can put the test tags there, either as a single tag string or as an array of tags.
+
+```js
+it('works as an array', { tags: ['config', 'some-other-tag'] }, () => {
+  expect(true).to.be.true
+})
+
+it('works as a string', { tags: 'config' }, () => {
+  expect(true).to.be.true
+})
+```
+
+You can run both of these tests using `--env grep=config` string.
+
 ## Examples
 
 - [cypress-grep-example](https://github.com/bahmutov/cypress-grep-example)

--- a/cypress/integration/config-tags-spec.js
+++ b/cypress/integration/config-tags-spec.js
@@ -1,0 +1,15 @@
+/// <reference types="cypress" />
+describe('tags in the config object', () => {
+  it('works as an array', { tags: ['config', 'some-other-tag'] }, () => {
+    expect(true).to.be.true
+  })
+
+  it('works as a string', { tags: 'config' }, () => {
+    expect(true).to.be.true
+  })
+
+  it('does not use tags', () => {
+    // so it fails
+    expect(true).to.be.false
+  })
+})

--- a/expects/config-tags-spec.json
+++ b/expects/config-tags-spec.json
@@ -1,0 +1,7 @@
+{
+  "tags in the config object": {
+    "works as an array": "passed",
+    "works as a string": "passed",
+    "does not use tags": "pending"
+  }
+}

--- a/src/support.js
+++ b/src/support.js
@@ -19,7 +19,7 @@ function cypressGrep() {
 
   const parsedGrep = parseGrep(grep)
 
-  it = (name, options, callback) => {
+  it = function (name, options, callback) {
     if (typeof options === 'function') {
       // the test has format it('...', cb)
       callback = options
@@ -31,7 +31,11 @@ function cypressGrep() {
       return _it(name, options)
     }
 
-    const shouldRun = shouldTestRun(parsedGrep, name)
+    let configTags = options && options.tags
+    if (typeof configTags === 'string') {
+      configTags = [configTags]
+    }
+    const shouldRun = shouldTestRun(parsedGrep, name, configTags)
 
     if (shouldRun) {
       return _it(name, options, callback)

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,14 +22,22 @@ function parseGrep(s) {
   return ORS
 }
 
-function shouldTestRun(parsedGrep, testName) {
+// note: tags take precedence over the test name
+function shouldTestRun(parsedGrep, testName, tags = []) {
   // top levels are OR
   return parsedGrep.some((orPart) => {
     return orPart.every((p) => {
       if (p.invert) {
+        if (tags.length) {
+          return !tags.includes(p.tag)
+        }
+
         return !testName.includes(p.tag)
       }
 
+      if (tags.length) {
+        return tags.includes(p.tag)
+      }
       return testName.includes(p.tag)
     })
   })


### PR DESCRIPTION
Cypress tests can have their own [test config object](https://on.cypress.io/configuration#Test-Configuration), and when using this plugin you can put the test tags there, either as a single tag string or as an array of tags.

```js
it('works as an array', { tags: ['config', 'some-other-tag'] }, () => {
  expect(true).to.be.true
})

it('works as a string', { tags: 'config' }, () => {
  expect(true).to.be.true
})
```

You can run both of these tests using `--env grep=config` string.