### PR TITLE
feat: implement describe tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,15 @@ jobs:
             --env grep=config \
             --expect expects/config-tags-spec.json
 
+      # skip tests by using describe tags
+      - name: Run e2e tests with tags on the describe 🧪
+        run: |
+          npx cypress-expect \
+            --spec cypress/integration/describe-tags-spec.js \
+            --config testFiles="describe-tags-spec.js" \
+            --env grep=-@smoke \
+            --expect expects/describe-tags-spec.json
+
       - name: Semantic Release 🚀
         uses: cycjimmy/semantic-release-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,23 @@ jobs:
             --expect expects/config-tags-spec.json
 
       # skip tests by using describe tags
-      - name: Run e2e tests with tags on the describe 🧪
+      - name: Run e2e tests with tags on the describe invert 🧪
         run: |
           npx cypress-expect \
             --spec cypress/integration/describe-tags-spec.js \
             --config testFiles="describe-tags-spec.js" \
             --env grep=-@smoke \
             --expect expects/describe-tags-invert-spec.json
+
+      # enable suite of tests using a tag
+      # DOES NOT WORK YET
+      - name: Enable suite of tests with a tag 🧪
+        run: |
+          npx cypress-expect \
+            --spec cypress/integration/describe-tags-spec.js \
+            --config testFiles="describe-tags-spec.js" \
+            --env grep=@smoke \
+            --expect expects/describe-tags-spec.json
 
       - name: Semantic Release 🚀
         uses: cycjimmy/semantic-release-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
             --spec cypress/integration/describe-tags-spec.js \
             --config testFiles="describe-tags-spec.js" \
             --env grep=-@smoke \
-            --expect expects/describe-tags-spec.json
+            --expect expects/describe-tags-invert-spec.json
 
       - name: Semantic Release 🚀
         uses: cycjimmy/semantic-release-action@v2

--- a/README.md
+++ b/README.md
@@ -136,6 +136,39 @@ it('runs on deploy', { tags: 'smoke' }, () => {
 })
 ```
 
+## Test suites
+
+The tags are also applied to the "describe" blocks, both as a substring and as config object tags. See the [cypress/integration/describe-tags-spec.js](./cypress/integration/describe-tags-spec.js) file.
+
+```js
+describe('block with tag @smoke', () => {
+  ...
+})
+
+// ALTERNATIVE: specify tags as the config property
+describe('block with config tag',
+  { tags: '@smoke' }, () => {
+})
+```
+
+## General advice
+
+- do not use spaces in the tags themselves, as `--env grep=...` string separates the grep string into OR tags using the space ` ` separator.
+- I like using `@` as tag prefix to make the tags searchable
+- I like using the test or suite configuration object to explicitly list the tags
+
+```js
+// ✅ good practice
+describe('auth', { tags: '@critical' }, () => ...)
+it('works', { tags: '@smoke' }, () => ...)
+it('works', { tags: ['@smoke', '@fast'] }, () => ...)
+
+// 🚨 NOT GOING TO WORK
+// ERROR: treated as a single tag,
+// probably want an array instead
+it('works', { tags: '@smoke @fast' }, () => ...)
+```
+
 ## Examples
 
 - [cypress-grep-example](https://github.com/bahmutov/cypress-grep-example)

--- a/README.md
+++ b/README.md
@@ -138,18 +138,18 @@ it('runs on deploy', { tags: 'smoke' }, () => {
 
 ## Test suites
 
-The tags are also applied to the "describe" blocks, both as a substring and as config object tags. See the [cypress/integration/describe-tags-spec.js](./cypress/integration/describe-tags-spec.js) file.
+The tags are also applied to the "describe" blocks with some limitations:
+
+- you can only use the config object tags
 
 ```js
-describe('block with tag @smoke', () => {
-  ...
-})
-
-// ALTERNATIVE: specify tags as the config property
-describe('block with config tag',
-  { tags: '@smoke' }, () => {
+describe('block with config tag', { tags: '@smoke' }, () => {
 })
 ```
+
+- currently only the invert tag to skip the blog has meaningful effect. For example you can skip the above suite of tests by using `--env grep=-@smoke` value. Keep an eye on issue [#22](https://github.com/bahmutov/cypress-grep/issues/22) for the full support implementation.
+
+See the [cypress/integration/describe-tags-spec.js](./cypress/integration/describe-tags-spec.js) file.
 
 ## General advice
 

--- a/cypress/integration/describe-tags-spec.js
+++ b/cypress/integration/describe-tags-spec.js
@@ -1,0 +1,15 @@
+/// <reference types="cypress" />
+
+// specify tag as substring
+describe('block with tag @smoke', () => {
+  it('inside describe 1', () => {})
+
+  it('inside describe 2', () => {})
+})
+
+// specify tag inside the config object
+describe('block with config tag', { tags: '@smoke' }, () => {
+  it('inside describe 3', () => {})
+
+  it('inside describe 4', () => {})
+})

--- a/cypress/integration/describe-tags-spec.js
+++ b/cypress/integration/describe-tags-spec.js
@@ -1,13 +1,16 @@
 /// <reference types="cypress" />
 
-// IGNORED: specify tag as substring
+// NOTE, IGNORED: specify tag as substring has no effect
 describe('block with tag @smoke', () => {
   it('inside describe 1', () => {})
 
   it('inside describe 2', () => {})
 })
 
-// WORKING: specify tag inside the config object
+// WORKING: ignore the entire suite using invert option
+//  --env grep=-@smoke
+// NOT WORKING: run all the tests in this suite only
+//  --env grep=@smoke
 describe('block with config tag', { tags: '@smoke' }, () => {
   it('inside describe 3', () => {})
 

--- a/cypress/integration/describe-tags-spec.js
+++ b/cypress/integration/describe-tags-spec.js
@@ -1,15 +1,21 @@
 /// <reference types="cypress" />
 
-// specify tag as substring
+// IGNORED: specify tag as substring
 describe('block with tag @smoke', () => {
   it('inside describe 1', () => {})
 
   it('inside describe 2', () => {})
 })
 
-// specify tag inside the config object
+// WORKING: specify tag inside the config object
 describe('block with config tag', { tags: '@smoke' }, () => {
   it('inside describe 3', () => {})
 
   it('inside describe 4', () => {})
+})
+
+describe('block without any tags', () => {
+  // note the parent suite has no tags
+  // so this test should run when using --eng grep=@smoke
+  it('still runs', { tags: '@smoke' }, () => {})
 })

--- a/expects/describe-tags-invert-spec.json
+++ b/expects/describe-tags-invert-spec.json
@@ -1,10 +1,13 @@
 {
   "block with tag @smoke": {
-    "inside describe 1": "pending",
-    "inside describe 2": "pending"
+    "inside describe 1": "pass",
+    "inside describe 2": "pass"
   },
   "block with config tag": {
     "inside describe 3": "pending",
     "inside describe 4": "pending"
+  },
+  "block without any tags": {
+    "still runs": "pending"
   }
 }

--- a/expects/describe-tags-spec.json
+++ b/expects/describe-tags-spec.json
@@ -1,0 +1,10 @@
+{
+  "block with tag @smoke": {
+    "inside describe 1": "pending",
+    "inside describe 2": "pending"
+  },
+  "block with config tag": {
+    "inside describe 3": "pending",
+    "inside describe 4": "pending"
+  }
+}

--- a/expects/describe-tags-spec.json
+++ b/expects/describe-tags-spec.json
@@ -1,0 +1,13 @@
+{
+  "block with tag @smoke": {
+    "inside describe 1": "pending",
+    "inside describe 2": "pending"
+  },
+  "block with config tag": {
+    "inside describe 3": "pending",
+    "inside describe 4": "pending"
+  },
+  "block without any tags": {
+    "still runs": "passed"
+  }
+}

--- a/src/support.js
+++ b/src/support.js
@@ -62,7 +62,17 @@ function cypressGrep() {
     if (typeof configTags === 'string') {
       configTags = [configTags]
     }
-    const shouldRun = shouldTestRun(parsedGrep, name, configTags)
+
+    if (!configTags || !configTags.length) {
+      // if the describe suite does not have explicit tags
+      // move on, since the tests inside can have their own tags
+      return _describe(name, options, callback)
+    }
+
+    // when looking at the suite of the tests, I found
+    // that using the name is quickly becoming very confusing
+    // and thus we need to use the explicit tags
+    const shouldRun = shouldTestRun(parsedGrep, configTags)
 
     if (shouldRun) {
       return _describe(name, options, callback)

--- a/src/support.js
+++ b/src/support.js
@@ -4,9 +4,10 @@ const { parseGrep, shouldTestRun } = require('./utils')
 
 // preserve the real "it" function
 const _it = it
+const _describe = describe
 
 /**
- * Wraps the "it" function with a new function.
+ * Wraps the "it" and "describe" functions that support tags.
  * @see https://github.com/bahmutov/cypress-grep
  */
 function cypressGrep() {
@@ -45,8 +46,35 @@ function cypressGrep() {
     return _it.skip(name, options, callback)
   }
 
+  describe = function (name, options, callback) {
+    if (typeof options === 'function') {
+      // the block has format describe('...', cb)
+      callback = options
+      options = {}
+    }
+
+    if (!callback) {
+      // the pending suite by itself
+      return _describe(name, options)
+    }
+
+    let configTags = options && options.tags
+    if (typeof configTags === 'string') {
+      configTags = [configTags]
+    }
+    const shouldRun = shouldTestRun(parsedGrep, name, configTags)
+
+    if (shouldRun) {
+      return _describe(name, options, callback)
+    }
+
+    // skip tests without grep string in their names
+    return _describe.skip(name, options, callback)
+  }
+
   // keep the "it.skip" the same as before
   it.skip = _it.skip
+  describe.skip = _describe.skip
 }
 
 module.exports = cypressGrep

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,6 +24,12 @@ function parseGrep(s) {
 
 // note: tags take precedence over the test name
 function shouldTestRun(parsedGrep, testName, tags = []) {
+  if (Array.isArray(testName)) {
+    // the caller passed tags only, no test name
+    tags = testName
+    testName = undefined
+  }
+
   // top levels are OR
   return parsedGrep.some((orPart) => {
     return orPart.every((p) => {
@@ -32,13 +38,24 @@ function shouldTestRun(parsedGrep, testName, tags = []) {
           return !tags.includes(p.tag)
         }
 
-        return !testName.includes(p.tag)
+        if (testName) {
+          return !testName.includes(p.tag)
+        }
+
+        // no tags, no test name
+        return true
       }
 
       if (tags.length) {
         return tags.includes(p.tag)
       }
-      return testName.includes(p.tag)
+
+      if (testName) {
+        return testName.includes(p.tag)
+      }
+
+      // no tags, no test name
+      return true
     })
   })
 }


### PR DESCRIPTION
for #22

The tags are also applied to the "describe" blocks with some limitations:

- you can only use the config object tags

```js
describe('block with config tag', { tags: '@smoke' }, () => {
})
```

- currently only the invert tag to skip the blog has a meaningful effect. For example, you can skip the above suite of tests by using `--env grep=-@smoke` value.