### PR TITLE
feat: rework tags and grep title

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
             --env grepTags=config \
             --expect expects/config-tags-spec.json
 
-      # skip tests by using describe tags
+      # skip tests by using the describe tags
       - name: Run e2e tests with tags on the describe invert 🧪
         run: |
           npx cypress-expect \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,11 @@ jobs:
             --env grepTags=-@tag1 \
             --expect ./expects/invert-tag1.json
 
-      - name: Run tests with hello and @tag1 🧪
+      - name: Run tests with title and tag 🧪
         run: |
           npx cypress-expect \
-            --env grep=hello,grepTags=@tag1 \
-            --expect ./expects/hello-and-tag1.json
+            --env grep=works,grepTags=@tag1 \
+            --expect ./expects/works-and-tag1.json
 
       # you can pass test tags in the config object
       - name: Run e2e tests with tags in the config 🧪

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           npx cypress-expect \
             --spec cypress/integration/describe-tags-spec.js \
             --config testFiles="describe-tags-spec.js" \
-            --env grep=-@smoke \
+            --env grepTags=-@smoke \
             --expect expects/describe-tags-invert-spec.json
 
       # enable suite of tests using a tag
@@ -115,7 +115,7 @@ jobs:
           npx cypress-expect \
             --spec cypress/integration/describe-tags-spec.js \
             --config testFiles="describe-tags-spec.js" \
-            --env grep=@smoke \
+            --env grepTags=@smoke \
             --expect expects/describe-tags-spec.json
 
       - name: Semantic Release 🚀

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,11 @@ jobs:
             --env grepTags=-@tag1 \
             --expect ./expects/invert-tag1.json
 
-      - name: Run tests with hello OR @tag1 🧪
+      - name: Run tests with hello and @tag1 🧪
         run: |
           npx cypress-expect \
-            --env grep='hello @tag1' \
-            --expect ./expects/hello-or-tag1.json
+            --env grep=hello,grepTags=@tag1 \
+            --expect ./expects/hello-and-tag1.json
 
       # you can pass test tags in the config object
       - name: Run e2e tests with tags in the config 🧪
@@ -96,7 +96,7 @@ jobs:
           npx cypress-expect \
             --spec cypress/integration/config-tags-spec.js \
             --config testFiles="config-tags-spec.js" \
-            --env grep=config \
+            --env grepTags=config \
             --expect expects/config-tags-spec.json
 
       # skip tests by using describe tags

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Run tests with "@tag1 AND @tag2" 🧪
         run: |
           npx cypress-expect \
-            --env grep=@tag1+@tag2 \
+            --env grepTags=@tag1+@tag2 \
             --expect ./expects/tag1-and-tag2.json
 
       - name: Run tests without @tag1 🧪

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Run tests without @tag1 🧪
         run: |
           npx cypress-expect \
-            --env grep=-@tag1 \
+            --env grepTags=-@tag1 \
             --expect ./expects/invert-tag1.json
 
       - name: Run tests with hello OR @tag1 🧪

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,13 @@ jobs:
             --env grep=hello \
             --expect ./expects/hello.json
 
+      # check space character
+      - name: Run tests with "works 2" 🧪
+        run: |
+          npx cypress-expect run \
+            --env grep="works 2" \
+            --expect ./expects/works-2.json
+
       - name: Run tests with "@tag1" 🧪
         run: |
           npx cypress-expect run \

--- a/README.md
+++ b/README.md
@@ -207,9 +207,11 @@ You can set the grep string from the DevTools Console. This plugin adds method `
 Cypress.grep('hello world')
 // filter tests by tag string
 // in this case will run tests with tag @smoke OR @fast
-Cypress.grepTags('@smoke @fast')
+Cypress.grep(null, '@smoke @fast')
 // run tests tagged @smoke AND @fast
-Cypress.grepTags('@smoke+@fast')
+Cypress.grep(null, '@smoke+@fast')
+// run tests with title containing "hello" and tag @smoke
+Cypress.grep('hello', '@smoke')
 ```
 
 - to remove the grep strings enter `Cypress.grep()`

--- a/README.md
+++ b/README.md
@@ -200,6 +200,33 @@ This module uses [debug](https://github.com/visionmedia/debug#readme) to log ver
 - [cypress-select-tests](https://github.com/bahmutov/cypress-select-tests)
 - [cypress-skip-test](https://github.com/cypress-io/cypress-skip-test)
 
+## Migration guide
+
+### from v1 to v2
+
+In v2 we have separated grepping by part of the title string from tags.
+
+**v1**
+
+```
+--env grep="one two"
+```
+
+The above scenario was confusing - did you want to find all tests with title containing "one two" or did you want to run tests tagged `one` or `two`?
+
+**v2**
+
+```
+# enable the tests with string "one two" in their titles
+--env grep="one two"
+# enable the tests with tag "one" or "two"
+--env grepTags="one two"
+# enable the tests with both tags "one" and "two"
+--env grepTags="one+two"
+# enable the tests with "hello" in the title and tag "smoke"
+--env grep=hello,grepTags=smoke
+```
+
 ## Small print
 
 Author: Gleb Bahmutov &lt;gleb.bahmutov@gmail.com&gt; &copy; 2021

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npx cypress run --env grep=hello
 
 All other tests will be marked pending, see why in the [Cypress test statuses](https://on.cypress.io/writing-and-organizing-tests#Test-statuses) blog post.
 
-If you have multiple spec files, all specs will be loaded, and every test will be filtered the same way, since the grep is run-time operation and cannot eliminate the spec files without loading them.
+If you have multiple spec files, all specs will be loaded, and every test will be filtered the same way, since the grep is run-time operation and cannot eliminate the spec files without loading them. If you want to run only specific tests, use the built-in [--spec](https://on.cypress.io/command-line#cypress-run-spec-lt-spec-gt) CLI argument.
 
 ## Install and use
 
@@ -54,17 +54,25 @@ The plugin code will print a little message on load, for example
 
 ```shell
 $ npx cypress run --env grep=hello
-cypress-grep: only running tests with "hello" in their names
+cypress-grep: tests with "hello" in their names
 ```
 
-## Filter by grep
+## Filter
 
-You can use any way to modify the environment value `grep` except the run-time `Cypress.env('grep')` (because it is too late at run-time). You can set the `grep` value in the `cypress.json` file to run only tests with the substring `@smoke` in their names
+You can filter tests to run using part of their title via `grep`, and via explicit tags via `grepTags` Cypress environment variables.
+
+Most likely you will pass these environment variables from the command line. For example, to only run tests with "login" in their title and tagged "smoke", you would run:
+
+```shell
+$ npx cypress run --env grep=login,grepTags=smoke
+```
+
+You can use any way to modify the environment values `grep` and `grepTags`, except the run-time `Cypress.env('grep')` (because it is too late at run-time). You can set the `grep` value in the `cypress.json` file to run only tests with the substring `viewport` in their names
 
 ```json
 {
   "env": {
-    "grep": "@smoke"
+    "grep": "viewport"
   }
 }
 ```
@@ -74,44 +82,27 @@ You can also set the `env.grep` object in the plugin file, but remember to retur
 ```js
 // cypress/plugin/index.js
 module.exports = (on, config) => {
-  config.env.grep = '@smoke'
+  config.env.grep = 'viewport'
   return config
 }
 ```
 
-Most likely you will pass the grep string via CLI when launching Cypress
+You can also set the grep and grepTags from the DevTools console while running Cypress in the interactive mode `cypress open`, see [DevTools Console section](#devtools-console).
+
+### grep by test title
 
 ```shell
-$ npx cypress run --env grep=@smoke
+# run all tests with "hello" in their title
+$ npx cypress run --env grep=hello
+# run all tests with "hello world" in their title
+$ npx cypress run --env grep="hello world"
+# run all tests WITHOUT "hello world" in their title
+$ npx cypress run --env grep="-hello world"
 ```
 
-### AND tags
+## Filter with tags
 
-Use `+` to require both tags to be present
-
-```
---env grep=@smoke+@fast
-```
-
-### Invert tag
-
-You can skip running the tests with specific tag using the invert option: prefix the tag with the character `-`.
-
-```
-# do not run any tests with tag "@slow"
---env grep=-@slow
-```
-
-### OR tags
-
-You can run tests that match one tag or another using spaces. Make sure to quote the grep string!
-
-```
-# run tests with tags "@slow" or "@critical" in their names
---env grep='@slow @critical'
-```
-
-## Tags in the test config object
+### Tags in the test config object
 
 Cypress tests can have their own [test config object](https://on.cypress.io/configuration#Test-Configuration), and when using this plugin you can put the test tags there, either as a single tag string or as an array of tags.
 
@@ -125,7 +116,7 @@ it('works as a string', { tags: 'config' }, () => {
 })
 ```
 
-You can run both of these tests using `--env grep=config` string.
+You can run both of these tests using `--env grepTags=config` string.
 
 ### TypeScript users
 
@@ -149,21 +140,46 @@ describe('block with config tag', { tags: '@smoke' }, () => {
 })
 ```
 
-- currently only the invert tag to skip the blog has meaningful effect. For example you can skip the above suite of tests by using `--env grep=-@smoke` value. Keep an eye on issue [#22](https://github.com/bahmutov/cypress-grep/issues/22) for the full support implementation.
+- currently only the invert tag to skip the blog has meaningful effect. For example you can skip the above suite of tests by using `--env grepTags=-@smoke` value. Keep an eye on issue [#22](https://github.com/bahmutov/cypress-grep/issues/22) for the full support implementation.
 
 See the [cypress/integration/describe-tags-spec.js](./cypress/integration/describe-tags-spec.js) file.
 
+### AND tags
+
+Use `+` to require both tags to be present
+
+```
+--env grepTags=@smoke+@fast
+```
+
+### Invert tag
+
+You can skip running the tests with specific tag using the invert option: prefix the tag with the character `-`.
+
+```
+# do not run any tests with tag "@slow"
+--env grepTags=-@slow
+```
+
+### OR tags
+
+You can run tests that match one tag or another using spaces. Make sure to quote the grep string!
+
+```
+# run tests with tags "@slow" or "@critical" in their names
+--env grepTags='@slow @critical'
+```
+
 ## General advice
 
-- do not use spaces in the tags themselves, as `--env grep=...` string separates the grep string into OR tags using the space ` ` separator.
+- keep it simple.
 - I like using `@` as tag prefix to make the tags searchable
-- I like using the test or suite configuration object to explicitly list the tags
 
 ```js
 // ✅ good practice
 describe('auth', { tags: '@critical' }, () => ...)
 it('works', { tags: '@smoke' }, () => ...)
-it('works', { tags: ['@smoke', '@fast'] }, () => ...)
+it('works quickly', { tags: ['@smoke', '@fast'] }, () => ...)
 
 // 🚨 NOT GOING TO WORK
 // ERROR: treated as a single tag,
@@ -171,19 +187,32 @@ it('works', { tags: ['@smoke', '@fast'] }, () => ...)
 it('works', { tags: '@smoke @fast' }, () => ...)
 ```
 
-## DevTools console
+Grepping the tests
 
-You can set the grep string from the DevTools Console. This plugin adds method `Cypress.grep` to set the grep string and restart the tests
-
-```js
-// use grep "@tag1"
-Cypress.grep('@tag1')
-// run the test with substring "hello world"
-// without parsing separate words as tags
-Cypress.grep(['hello world'])
+```shell
+# run the tests by title
+$ npx cypress run --env grep="works quickly"
+# run all tests tagged @smoke
+$ npx cypress run --env grepTags=@smoke
+# run all tests except tagged @smoke
+$ npx cypress run --env grepTags=-@smoke
 ```
 
-- to remove the grep string, enter `Cypress.grep()`
+## DevTools console
+
+You can set the grep string from the DevTools Console. This plugin adds method `Cypress.grep` and `Cypress.grepTags` to set the grep strings and restart the tests
+
+```js
+// filter tests by title substring
+Cypress.grep('hello world')
+// filter tests by tag string
+// in this case will run tests with tag @smoke OR @fast
+Cypress.grepTags('@smoke @fast')
+// run tests tagged @smoke AND @fast
+Cypress.grepTags('@smoke+@fast')
+```
+
+- to remove the grep strings enter `Cypress.grep()`
 
 ## Debugging
 

--- a/cypress/integration/describe-tags-spec.js
+++ b/cypress/integration/describe-tags-spec.js
@@ -1,16 +1,15 @@
 /// <reference types="cypress" />
 
-// NOTE, IGNORED: specify tag as substring has no effect
-describe('block with tag @smoke', () => {
+describe('block with no tags', () => {
   it('inside describe 1', () => {})
 
   it('inside describe 2', () => {})
 })
 
 // WORKING: ignore the entire suite using invert option
-//  --env grep=-@smoke
+//  --env grepTags=-@smoke
 // NOT WORKING: run all the tests in this suite only
-//  --env grep=@smoke
+//  --env grepTags=@smoke
 describe('block with config tag', { tags: '@smoke' }, () => {
   it('inside describe 3', () => {})
 
@@ -19,6 +18,6 @@ describe('block with config tag', { tags: '@smoke' }, () => {
 
 describe('block without any tags', () => {
   // note the parent suite has no tags
-  // so this test should run when using --eng grep=@smoke
+  // so this test should run when using --eng grepTags=@smoke
   it('still runs', { tags: '@smoke' }, () => {})
 })

--- a/cypress/integration/describe-tags-spec.js
+++ b/cypress/integration/describe-tags-spec.js
@@ -10,7 +10,7 @@ describe('block with no tags', () => {
 //  --env grepTags=-@smoke
 // NOT WORKING: run all the tests in this suite only
 //  --env grepTags=@smoke
-describe('block with config tag', { tags: '@smoke' }, () => {
+describe('block with tag smoke', { tags: '@smoke' }, () => {
   it('inside describe 3', () => {})
 
   it('inside describe 4', () => {})
@@ -19,5 +19,5 @@ describe('block with config tag', { tags: '@smoke' }, () => {
 describe('block without any tags', () => {
   // note the parent suite has no tags
   // so this test should run when using --eng grepTags=@smoke
-  it('still runs', { tags: '@smoke' }, () => {})
+  it('test with tag smoke', { tags: '@smoke' }, () => {})
 })

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -4,8 +4,8 @@ it('hello world', () => {})
 
 it('works', () => {})
 
-it('works 2 @tag1', () => {})
+it('works 2 @tag1', { tags: '@tag1' }, () => {})
 
-it('works 2 @tag1 @tag2', () => {})
+it('works 2 @tag1 @tag2', { tags: ['@tag1', '@tag2'] }, () => {})
 
-it('works @tag2', () => {})
+it('works @tag2', { tags: '@tag2' }, () => {})

--- a/cypress/integration/unit.js
+++ b/cypress/integration/unit.js
@@ -58,6 +58,11 @@ describe('utils', () => {
       ])
     })
 
+    it('parses inverted tag', () => {
+      const parsed = parseTagsGrep('-@tag1')
+      expect(parsed).to.deep.equal([[{ tag: '@tag1', invert: true }]])
+    })
+
     it('parses tag1 but not tag2 with space', () => {
       const parsed = parseTagsGrep('@tag1 -@tag2')
       expect(parsed).to.deep.equal([
@@ -185,6 +190,8 @@ describe('utils', () => {
       shouldIt('smoke -slow', ['smoke', 'fast'], true)
       shouldIt('-slow', ['smoke', 'slow'], false)
       shouldIt('-slow', ['smoke'], true)
+      // no tags in the test
+      shouldIt('-slow', [], true)
     })
   })
 
@@ -208,10 +215,17 @@ describe('utils', () => {
       expect(shouldTestRun(parsed, 'has @tag1 in the name')).to.be.true
     })
 
+    it('with invert title', () => {
+      const t = checkName('-hello')
+      expect(t('no greetings')).to.be.true
+      expect(t('has hello world')).to.be.false
+    })
+
     it('with invert option', () => {
-      const t = checkName('-@tag1')
-      expect(t('no tag1 here')).to.be.true
-      expect(t('has @tag1 in the name')).to.be.false
+      const t = checkName(null, '-@tag1')
+      expect(t('no tags here')).to.be.true
+      expect(t('has tag1', ['@tag1'])).to.be.false
+      expect(t('has other tags', ['@tag2'])).to.be.true
     })
 
     it('with AND option', () => {

--- a/cypress/integration/unit.js
+++ b/cypress/integration/unit.js
@@ -1,15 +1,42 @@
 /// <reference types="cypress" />
 
-import { parseGrep, shouldTestRun } from '../../src/utils'
+import {
+  parseGrep,
+  parseTitleGrep,
+  parseTagsGrep,
+  shouldTestRun,
+  shouldTestRunTags,
+  shouldTestRunTitle,
+} from '../../src/utils'
 
 describe('utils', () => {
-  context('parseGrep', () => {
-    // no need to exhaustively test the parsing
-    // since we want to confirm it works via test names
-    // and not through the implementation details of
-    // the parsed object
-    it('creates objects from the grep string', () => {
-      const parsed = parseGrep('@tag1+@tag2+@tag3')
+  context('parseTitleGrep', () => {
+    it('grabs the positive title', () => {
+      const parsed = parseTitleGrep('hello w')
+      expect(parsed).to.deep.equal({
+        title: 'hello w',
+        invert: false,
+      })
+    })
+
+    it('inverts the string', () => {
+      const parsed = parseTitleGrep('-hello w')
+      expect(parsed).to.deep.equal({
+        title: 'hello w',
+        invert: true,
+      })
+    })
+
+    it('returns null for undefined input', () => {
+      const parsed = parseTitleGrep()
+      expect(parsed).to.equal(null)
+    })
+  })
+
+  context('parseTagsGrep', () => {
+    it('parses AND tags', () => {
+      // run only the tests with all 3 tags
+      const parsed = parseTagsGrep('@tag1+@tag2+@tag3')
       expect(parsed).to.deep.equal([
         // single OR part
         [
@@ -21,24 +48,157 @@ describe('utils', () => {
       ])
     })
 
-    it('assumes env grep array is a single string', () => {
-      const parsed = parseGrep(['hello world'])
-      expect(parsed, 'does not split an array').to.deep.equal([
-        [{ tag: 'hello world', invert: false }],
+    it('parses OR tags', () => {
+      // run tests with tag1 OR tag2 or tag3
+      const parsed = parseTagsGrep('@tag1 @tag2 @tag3')
+      expect(parsed).to.deep.equal([
+        [{ tag: '@tag1', invert: false }],
+        [{ tag: '@tag2', invert: false }],
+        [{ tag: '@tag3', invert: false }],
       ])
+    })
+
+    it('parses tag1 but not tag2 with space', () => {
+      const parsed = parseTagsGrep('@tag1 -@tag2')
+      expect(parsed).to.deep.equal([
+        [{ tag: '@tag1', invert: false }],
+        [{ tag: '@tag2', invert: true }],
+      ])
+    })
+
+    // would need to change the tokenizer
+    it.skip('parses tag1 but not tag2', () => {
+      const parsed = parseTagsGrep('@tag1-@tag2')
+      expect(parsed).to.deep.equal([
+        [
+          { tag: '@tag1', invert: false },
+          { tag: '@tag2', invert: true },
+        ],
+      ])
+    })
+  })
+
+  context('parseGrep', () => {
+    // no need to exhaustively test the parsing
+    // since we want to confirm it works via test names
+    // and not through the implementation details of
+    // the parsed object
+
+    it('creates just the title grep', () => {
+      const parsed = parseGrep('hello w')
+      expect(parsed).to.deep.equal({
+        title: {
+          title: 'hello w',
+          invert: false,
+        },
+        tags: [],
+      })
+    })
+
+    it('creates object from the grep string only', () => {
+      const parsed = parseGrep('hello w')
+      expect(parsed).to.deep.equal({
+        title: {
+          title: 'hello w',
+          invert: false,
+        },
+        tags: [],
+      })
+
+      // check how the parsed grep works against specific tests
+      expect(shouldTestRun(parsed, 'hello w')).to.equal(true)
+      expect(shouldTestRun(parsed, 'hello no')).to.equal(false)
+    })
+
+    it('creates object from the grep string and tags', () => {
+      const parsed = parseGrep('hello w', '@tag1+@tag2+@tag3')
+      expect(parsed).to.deep.equal({
+        title: {
+          title: 'hello w',
+          invert: false,
+        },
+        tags: [
+          // single OR part
+          [
+            // with 3 AND parts
+            { tag: '@tag1', invert: false },
+            { tag: '@tag2', invert: false },
+            { tag: '@tag3', invert: false },
+          ],
+        ],
+      })
+
+      // check how the parsed grep works against specific tests
+      expect(shouldTestRun(parsed, 'hello w'), 'needs tags').to.equal(false)
+      expect(shouldTestRun(parsed, 'hello no')).to.equal(false)
+      // not every tag is present
+      expect(shouldTestRun(parsed, ['@tag1', '@tag2'])).to.equal(false)
+      expect(shouldTestRun(parsed, ['@tag1', '@tag2', '@tag3'])).to.equal(true)
+      expect(
+        shouldTestRun(parsed, ['@tag1', '@tag2', '@tag3', '@tag4']),
+      ).to.equal(true)
+      // title matches, but tags do not
+      expect(shouldTestRun(parsed, 'hello w', ['@tag1', '@tag2'])).to.equal(
+        false,
+      )
+
+      // tags and title match
+      expect(
+        shouldTestRun(parsed, 'hello w', ['@tag1', '@tag2', '@tag3']),
+      ).to.equal(true)
+    })
+  })
+
+  context('shouldTestRunTags', () => {
+    // when the user types "used" string
+    // and the test has the given tags, make sure
+    // our parsing and decision logic computes the expected result
+    const shouldIt = (used, tags, expected) => {
+      const parsedTags = parseTagsGrep(used)
+      console.log(parsedTags)
+      expect(
+        shouldTestRunTags(parsedTags, tags),
+        `"${used}" against "${tags}"`,
+      ).to.equal(expected)
+    }
+
+    it('handles AND tags', () => {
+      shouldIt('smoke+slow', ['fast', 'smoke'], false)
+      shouldIt('smoke+slow', ['mobile', 'smoke', 'slow'], true)
+      shouldIt('smoke+slow', ['slow', 'extra', 'smoke'], true)
+      shouldIt('smoke+slow', ['smoke'], false)
+    })
+
+    it('handles OR tags', () => {
+      // smoke OR slow
+      shouldIt('smoke slow', ['fast', 'smoke'], true)
+      shouldIt('smoke', ['mobile', 'smoke', 'slow'], true)
+      shouldIt('slow', ['slow', 'extra', 'smoke'], true)
+      shouldIt('smoke', ['smoke'], true)
+      shouldIt('smoke', ['slow'], false)
+    })
+
+    it('handles invert tag', () => {
+      // should not run - we are excluding the "slow"
+      shouldIt('smoke+-slow', ['smoke', 'slow'], false)
+      shouldIt('mobile+-slow', ['smoke', 'slow'], false)
+      shouldIt('smoke -slow', ['smoke', 'fast'], true)
+      shouldIt('-slow', ['smoke', 'slow'], false)
+      shouldIt('-slow', ['smoke'], true)
     })
   })
 
   context('shouldTestRun', () => {
     // a little utility function to parse the given grep string
     // and apply the first argument in shouldTestRun
-    const checkName = (grep) => {
-      const parsed = parseGrep(grep)
-      expect(parsed).to.be.an('array')
+    const checkName = (grep, grepTags) => {
+      const parsed = parseGrep(grep, grepTags)
+      expect(parsed).to.be.an('object')
 
-      return (testName) => {
-        expect(testName).to.be.a('string')
-        return shouldTestRun(parsed, testName)
+      return (testName, testTags = []) => {
+        expect(testName, 'test title').to.be.a('string')
+        expect(testTags, 'test tags').to.be.an('array')
+        return shouldTestRun(parsed, testName, testTags)
       }
     }
 
@@ -55,34 +215,51 @@ describe('utils', () => {
     })
 
     it('with AND option', () => {
-      const t = checkName('@tag1+@tag2')
+      const t = checkName('', '@tag1+@tag2')
       expect(t('no tag1 here')).to.be.false
-      expect(t('has only @tag1 in the name')).to.be.false
-      expect(t('has only @tag2 in the name')).to.be.false
-      expect(t('has @tag1 and @tag2 in the name')).to.be.true
+      expect(t('has only @tag1', ['@tag1'])).to.be.false
+      expect(t('has only @tag2', ['@tag2'])).to.be.false
+      expect(t('has both tags', ['@tag1', '@tag2'])).to.be.true
     })
 
     it('with OR option', () => {
-      const t = checkName('@tag1 @tag2')
+      const t = checkName(null, '@tag1 @tag2')
       expect(t('no tag1 here')).to.be.false
-      expect(t('has only @tag1 in the name')).to.be.true
-      expect(t('has only @tag2 in the name')).to.be.true
-      expect(t('has @tag1 and @tag2 in the name')).to.be.true
+      expect(t('has only @tag1 in the name', ['@tag1'])).to.be.true
+      expect(t('has only @tag2 in the name', ['@tag2'])).to.be.true
+      expect(t('has @tag1 and @tag2 in the name', ['@tag1', '@tag2'])).to.be
+        .true
     })
 
     it('OR with AND option', () => {
-      const t = checkName('@tag1 @tag2+@tag3')
+      const t = checkName(null, '@tag1 @tag2+@tag3')
       expect(t('no tag1 here')).to.be.false
-      expect(t('has only @tag1 in the name')).to.be.true
-      expect(t('has only @tag2 in the name')).to.be.false
-      expect(t('has only @tag2 in the name and also @tag3')).to.be.true
-      expect(t('has @tag1 and @tag2 and @tag3 in the name')).to.be.true
+      expect(t('has only @tag1 in the name', ['@tag1'])).to.be.true
+      expect(t('has only @tag2 in the name', ['@tag2'])).to.be.false
+      expect(t('has only @tag2 in the name and also @tag3', ['@tag2', '@tag3']))
+        .to.be.true
+      expect(
+        t('has @tag1 and @tag2 and @tag3 in the name', [
+          '@tag1',
+          '@tag2',
+          '@tag3',
+        ]),
+      ).to.be.true
     })
+  })
 
-    it('parsed [string] as a single tag', () => {
-      const t = checkName(['hello world!'])
-      expect(t('hello')).to.be.false
-      expect(t('has hello world! in the title')).to.be.true
+  context('shouldTestRunTitle', () => {
+    const shouldIt = (search, testName, expected) => {
+      const parsed = parseTitleGrep(search)
+      expect(
+        shouldTestRunTitle(parsed, testName),
+        `"${search}" against title "${testName}"`,
+      ).to.equal(expected)
+    }
+
+    it('passes for substring', () => {
+      shouldIt('hello w', 'hello world', true)
+      shouldIt('-hello w', 'hello world', false)
     })
   })
 })

--- a/expects/describe-tags-invert-spec.json
+++ b/expects/describe-tags-invert-spec.json
@@ -1,13 +1,13 @@
 {
-  "block with tag @smoke": {
-    "inside describe 1": "pass",
-    "inside describe 2": "pass"
+  "block with no tags": {
+    "inside describe 1": "passing",
+    "inside describe 2": "passing"
   },
-  "block with config tag": {
+  "block with tag smoke": {
     "inside describe 3": "pending",
     "inside describe 4": "pending"
   },
   "block without any tags": {
-    "still runs": "pending"
+    "test with tag smoke": "pending"
   }
 }

--- a/expects/describe-tags-spec.json
+++ b/expects/describe-tags-spec.json
@@ -1,13 +1,13 @@
 {
-  "block with tag @smoke": {
+  "block with no tags": {
     "inside describe 1": "pending",
     "inside describe 2": "pending"
   },
-  "block with config tag": {
+  "block with tag smoke": {
     "inside describe 3": "pending",
     "inside describe 4": "pending"
   },
   "block without any tags": {
-    "still runs": "passed"
+    "test with tag smoke": "passed"
   }
 }

--- a/expects/hello-and-tag1.json
+++ b/expects/hello-and-tag1.json
@@ -1,0 +1,7 @@
+{
+  "hello world": "pending",
+  "works": "pending",
+  "works 2 @tag1": "pending",
+  "works 2 @tag1 @tag2": "pending",
+  "works @tag2": "pending"
+}

--- a/expects/hello-or-tag1.json
+++ b/expects/hello-or-tag1.json
@@ -1,7 +1,0 @@
-{
-  "hello world": "passed",
-  "works": "pending",
-  "works 2 @tag1": "passed",
-  "works 2 @tag1 @tag2": "passed",
-  "works @tag2": "pending"
-}

--- a/expects/works-2.json
+++ b/expects/works-2.json
@@ -1,0 +1,7 @@
+{
+  "hello world": "pending",
+  "works": "pending",
+  "works 2 @tag1": "passing",
+  "works 2 @tag1 @tag2": "passing",
+  "works @tag2": "pending"
+}

--- a/expects/works-and-tag1.json
+++ b/expects/works-and-tag1.json
@@ -1,7 +1,7 @@
 {
   "hello world": "pending",
   "works": "pending",
-  "works 2 @tag1": "pending",
-  "works 2 @tag1 @tag2": "pending",
+  "works 2 @tag1": "passing",
+  "works 2 @tag1 @tag2": "passing",
   "works @tag2": "pending"
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,9 +1,14 @@
 function cypressGrepPlugin(config) {
-  if (config && config.env && config.env.grep) {
-    console.log(
-      'cypress-grep: only running tests with "%s" in their names',
-      config.env.grep,
-    )
+  if (config && config.env) {
+    if (config.env.grep) {
+      console.log(
+        'cypress-grep: tests with "%s" in their names',
+        config.env.grep,
+      )
+    }
+    if (config.env.grepTags) {
+      console.log('cypress-grep: filtering using tag "%s"', config.env.grepTags)
+    }
   }
 }
 

--- a/src/support.js
+++ b/src/support.js
@@ -25,7 +25,7 @@ function cypressGrep() {
   }
 
   debug('grep %o', { grep, grepTags })
-  const parsedGrep = parseGrep(grep)
+  const parsedGrep = parseGrep(grep, grepTags)
   debug('parsed grep %o', parsedGrep)
 
   it = function (name, options, callback) {

--- a/src/support.js
+++ b/src/support.js
@@ -13,15 +13,18 @@ const _describe = describe
  * @see https://github.com/bahmutov/cypress-grep
  */
 function cypressGrep() {
+  /** @type {string} Part of the test title go grep */
   const grep = Cypress.env('grep')
+  /** @type {string} Raw tags to grep string */
+  const grepTags = Cypress.env('grepTags') || Cypress.env('grep-tags')
 
-  if (!grep) {
+  if (!grep && !grepTags) {
     // nothing to do, the user has no specified the "grep" string
     debug('Nothing to grep')
     return
   }
 
-  debug('parsing grep string "%s"', grep)
+  debug('grep %o', { grep, grepTags })
   const parsedGrep = parseGrep(grep)
   debug('parsed grep %o', parsedGrep)
 
@@ -92,14 +95,26 @@ function cypressGrep() {
   describe.skip = _describe.skip
 }
 
+function restartTests() {
+  setTimeout(() => {
+    window.top.document.querySelector('.reporter .restart').click()
+  }, 0)
+}
+
 if (!Cypress.grep) {
   // expose a utility method to set the grep and run the tests
   Cypress.grep = function grep(s) {
     Cypress.env('grep', s)
-    debug('set new grep to "%s", restarting', s)
-    setTimeout(() => {
-      window.top.document.querySelector('.reporter .restart').click()
-    }, 0)
+    debug('set new grep to "%s", restarting tests', s)
+    restartTests()
+  }
+}
+
+if (!Cypress.grepTags) {
+  Cypress.grepTags = function grepTags(s) {
+    Cypress.env('grepTags', s)
+    debug('set new grep tags to "%s", restarting tests', s)
+    restartTests()
   }
 }
 

--- a/src/support.js
+++ b/src/support.js
@@ -103,17 +103,11 @@ function restartTests() {
 
 if (!Cypress.grep) {
   // expose a utility method to set the grep and run the tests
-  Cypress.grep = function grep(s) {
+  Cypress.grep = function grep(s, tags) {
     Cypress.env('grep', s)
-    debug('set new grep to "%s", restarting tests', s)
-    restartTests()
-  }
-}
+    Cypress.env('grepTags', tags)
 
-if (!Cypress.grepTags) {
-  Cypress.grepTags = function grepTags(s) {
-    Cypress.env('grepTags', s)
-    debug('set new grep tags to "%s", restarting tests', s)
+    debug('set new grep to "%s", tags to "%s", restarting tests', s, tags)
     restartTests()
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -60,11 +60,6 @@ function shouldTestRunTags(parsedGrepTags, tags = []) {
     return true
   }
 
-  if (!tags.length) {
-    // the test has no tags, it should not run
-    return false
-  }
-
   // now the test has tags and the parsed tags are present
 
   // top levels are OR

--- a/src/utils.js
+++ b/src/utils.js
@@ -81,7 +81,7 @@ function shouldTestRunTags(parsedGrepTags, tags = []) {
     return everyAndPartMatched
   })
 
-  console.log('onePartMatched', onePartMatched)
+  // console.log('onePartMatched', onePartMatched)
   return onePartMatched
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,17 +1,34 @@
-function parseGrep(s) {
-  if (Array.isArray(s)) {
-    if (s.length !== 1) {
-      throw new Error('Assumed grep [...] would have a single string in it')
-    }
+// @ts-check
 
-    return [
-      [
-        {
-          tag: s[0],
-          invert: false,
-        },
-      ],
-    ]
+/**
+ * Parses test title grep string.
+ * The string can have "-" in front of it to invert the match.
+ * @param {string} s Input substring of the test title
+ */
+function parseTitleGrep(s) {
+  if (!s || typeof s !== 'string') {
+    return null
+  }
+
+  if (s.startsWith('-')) {
+    return {
+      title: s.substr(1),
+      invert: true,
+    }
+  }
+  return {
+    title: s,
+    invert: false,
+  }
+}
+
+/**
+ * Parses tags to grep for.
+ * @param {string} s Tags string like "@tag1+@tag2"
+ */
+function parseTagsGrep(s) {
+  if (!s) {
+    return []
   }
 
   // top level split - using space, each part is OR
@@ -37,6 +54,53 @@ function parseGrep(s) {
   return ORS
 }
 
+function shouldTestRunTags(parsedGrepTags, tags = []) {
+  if (!parsedGrepTags.length) {
+    // there are no parsed tags to search for, the test should run
+    return true
+  }
+
+  if (!tags.length) {
+    // the test has no tags, it should not run
+    return false
+  }
+
+  // now the test has tags and the parsed tags are present
+
+  // top levels are OR
+  const onePartMatched = parsedGrepTags.some((orPart) => {
+    const everyAndPartMatched = orPart.every((p) => {
+      if (p.invert) {
+        return !tags.includes(p.tag)
+      }
+
+      return tags.includes(p.tag)
+    })
+    // console.log('every part matched %o?', orPart, everyAndPartMatched)
+
+    return everyAndPartMatched
+  })
+
+  console.log('onePartMatched', onePartMatched)
+  return onePartMatched
+}
+
+function shouldTestRunTitle(parsedGrep, testName) {
+  if (!testName) {
+    // if there is no title, let it run
+    return true
+  }
+  if (!parsedGrep) {
+    return true
+  }
+
+  if (parsedGrep.invert) {
+    return !testName.includes(parsedGrep.title)
+  }
+
+  return testName.includes(parsedGrep.title)
+}
+
 // note: tags take precedence over the test name
 function shouldTestRun(parsedGrep, testName, tags = []) {
   if (Array.isArray(testName)) {
@@ -45,34 +109,24 @@ function shouldTestRun(parsedGrep, testName, tags = []) {
     testName = undefined
   }
 
-  // top levels are OR
-  return parsedGrep.some((orPart) => {
-    return orPart.every((p) => {
-      if (p.invert) {
-        if (tags.length) {
-          return !tags.includes(p.tag)
-        }
-
-        if (testName) {
-          return !testName.includes(p.tag)
-        }
-
-        // no tags, no test name
-        return true
-      }
-
-      if (tags.length) {
-        return tags.includes(p.tag)
-      }
-
-      if (testName) {
-        return testName.includes(p.tag)
-      }
-
-      // no tags, no test name
-      return true
-    })
-  })
+  return (
+    shouldTestRunTitle(parsedGrep.title, testName) &&
+    shouldTestRunTags(parsedGrep.tags, tags)
+  )
 }
 
-module.exports = { parseGrep, shouldTestRun }
+function parseGrep(titlePart, tags) {
+  return {
+    title: parseTitleGrep(titlePart),
+    tags: parseTagsGrep(tags),
+  }
+}
+
+module.exports = {
+  parseGrep,
+  parseTitleGrep,
+  parseTagsGrep,
+  shouldTestRun,
+  shouldTestRunTags,
+  shouldTestRunTitle,
+}


### PR DESCRIPTION
BREAKING CHANGE: separate title grep from tags

closes #25 

Separates grep by title string from grep by explicit tags

```shell
$ npx cypress run --env grep=login,grepTags=smoke
```
