### PR TITLE
Grep with multiple titles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run tests with "hello" or "works 2" 🧪
         run: |
           npx cypress-expect run \
-            --env grep="hello, works 2" \
+            --env grep="hello; works 2" \
             --expect ./expects/hello-or-works-2.json
 
       - name: Run tests with "@tag1" 🧪

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,19 @@ jobs:
             --env grep="works 2" \
             --expect ./expects/works-2.json
 
+      # trims the grep string
+      - name: Run tests with "works 2" 🧪
+        run: |
+          npx cypress-expect run \
+            --env grep="  works 2    " \
+            --expect ./expects/works-2.json
+
+      - name: Run tests with "hello" or "works 2" 🧪
+        run: |
+          npx cypress-expect run \
+            --env grep="hello, works 2" \
+            --expect ./expects/hello-or-works-2.json
+
       - name: Run tests with "@tag1" 🧪
         run: |
           npx cypress-expect run \

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Start grepping by title and tags:
 ```shell
 # run only the tests with "auth user" in the title
 $ npx cypress run --env grep="auth user"
+# run tests with "hello" or "auth user" in their titles
+# by separating them with ";" character
+$ npx cypress run --env grep="hello; auth user"
 # run tests tagged @fast
 $ npx cypress run --env grepTags=@fast
 # run only the tests tagged "smoke"
@@ -132,6 +135,13 @@ $ npx cypress run --env grep=hello
 $ npx cypress run --env grep="hello world"
 # run all tests WITHOUT "hello world" in their title
 $ npx cypress run --env grep="-hello world"
+```
+
+You can pass multiple title substrings to match separating them with `;` character. Each substring is trimmed.
+
+```shell
+# run all tests with "hello world" or "auth user" in their title
+$ npx cypress run --env grep="hello world; auth user"
 ```
 
 ## Filter with tags

--- a/cypress/integration/unit.js
+++ b/cypress/integration/unit.js
@@ -3,6 +3,7 @@
 import {
   parseGrep,
   parseTitleGrep,
+  parseFullTitleGrep,
   parseTagsGrep,
   shouldTestRun,
   shouldTestRunTags,
@@ -19,8 +20,24 @@ describe('utils', () => {
       })
     })
 
+    it('trims the string', () => {
+      const parsed = parseTitleGrep('   hello w  ')
+      expect(parsed).to.deep.equal({
+        title: 'hello w',
+        invert: false,
+      })
+    })
+
     it('inverts the string', () => {
       const parsed = parseTitleGrep('-hello w')
+      expect(parsed).to.deep.equal({
+        title: 'hello w',
+        invert: true,
+      })
+    })
+
+    it('trims the inverted the string', () => {
+      const parsed = parseTitleGrep('  -hello w  ')
       expect(parsed).to.deep.equal({
         title: 'hello w',
         invert: true,
@@ -30,6 +47,17 @@ describe('utils', () => {
     it('returns null for undefined input', () => {
       const parsed = parseTitleGrep()
       expect(parsed).to.equal(null)
+    })
+  })
+
+  context('parseFullTitleGrep', () => {
+    it('returns list of title greps', () => {
+      const parsed = parseFullTitleGrep('hello; one; -two')
+      expect(parsed).to.deep.equal([
+        { title: 'hello', invert: false },
+        { title: 'one', invert: false },
+        { title: 'two', invert: true },
+      ])
     })
   })
 

--- a/cypress/integration/unit.js
+++ b/cypress/integration/unit.js
@@ -120,10 +120,12 @@ describe('utils', () => {
     it('creates just the title grep', () => {
       const parsed = parseGrep('hello w')
       expect(parsed).to.deep.equal({
-        title: {
-          title: 'hello w',
-          invert: false,
-        },
+        title: [
+          {
+            title: 'hello w',
+            invert: false,
+          },
+        ],
         tags: [],
       })
     })
@@ -131,10 +133,12 @@ describe('utils', () => {
     it('creates object from the grep string only', () => {
       const parsed = parseGrep('hello w')
       expect(parsed).to.deep.equal({
-        title: {
-          title: 'hello w',
-          invert: false,
-        },
+        title: [
+          {
+            title: 'hello w',
+            invert: false,
+          },
+        ],
         tags: [],
       })
 
@@ -143,13 +147,39 @@ describe('utils', () => {
       expect(shouldTestRun(parsed, 'hello no')).to.equal(false)
     })
 
+    it('matches one of the titles', () => {
+      // also should trim each title
+      const parsed = parseGrep('  hello w; work 2  ')
+
+      expect(parsed).to.deep.equal({
+        title: [
+          {
+            title: 'hello w',
+            invert: false,
+          },
+          {
+            title: 'work 2',
+            invert: false,
+          },
+        ],
+        tags: [],
+      })
+
+      // check how the parsed grep works against specific tests
+      expect(shouldTestRun(parsed, 'hello w')).to.equal(true)
+      expect(shouldTestRun(parsed, 'this work 2 works')).to.equal(true)
+      expect(shouldTestRun(parsed, 'hello no')).to.equal(false)
+    })
+
     it('creates object from the grep string and tags', () => {
       const parsed = parseGrep('hello w', '@tag1+@tag2+@tag3')
       expect(parsed).to.deep.equal({
-        title: {
-          title: 'hello w',
-          invert: false,
-        },
+        title: [
+          {
+            title: 'hello w',
+            invert: false,
+          },
+        ],
         tags: [
           // single OR part
           [
@@ -290,9 +320,9 @@ describe('utils', () => {
     })
   })
 
-  context('shouldTestRunTitle', () => {
+  context('parseFullTitleGrep', () => {
     const shouldIt = (search, testName, expected) => {
-      const parsed = parseTitleGrep(search)
+      const parsed = parseFullTitleGrep(search)
       expect(
         shouldTestRunTitle(parsed, testName),
         `"${search}" against title "${testName}"`,

--- a/expects/hello-or-works-2.json
+++ b/expects/hello-or-works-2.json
@@ -1,0 +1,7 @@
+{
+  "hello world": "passed",
+  "works": "pending",
+  "works 2 @tag1": "passed",
+  "works 2 @tag1 @tag2": "passed",
+  "works @tag2": "pending"
+}

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,8 +1,13 @@
+/**
+ * Prints the cypress-grep environment values if any.
+ * Only informs the user, does not modify the config.
+ * @param {Cypress.PluginConfigOptions} config
+ */
 function cypressGrepPlugin(config) {
   if (config && config.env) {
     const grep = config.env.grep
     if (grep) {
-      console.log('cypress-grep: tests with "%s" in their names', grep)
+      console.log('cypress-grep: tests with "%s" in their names', grep.trim())
     }
 
     const grepTags = config.env.grepTags || config.env['grep-tags']

--- a/src/support.js
+++ b/src/support.js
@@ -14,7 +14,11 @@ const _describe = describe
  */
 function cypressGrep() {
   /** @type {string} Part of the test title go grep */
-  const grep = Cypress.env('grep')
+  let grep = Cypress.env('grep')
+  if (grep) {
+    grep = grep.trim()
+  }
+
   /** @type {string} Raw tags to grep string */
   const grepTags = Cypress.env('grepTags') || Cypress.env('grep-tags')
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+// Universal code - should run in Node or in the browser
+
 /**
  * Parses test title grep string.
  * The string can have "-" in front of it to invert the match.
@@ -10,6 +12,7 @@ function parseTitleGrep(s) {
     return null
   }
 
+  s = s.trim()
   if (s.startsWith('-')) {
     return {
       title: s.substr(1),
@@ -20,6 +23,15 @@ function parseTitleGrep(s) {
     title: s,
     invert: false,
   }
+}
+
+function parseFullTitleGrep(s) {
+  if (!s || typeof s !== 'string') {
+    return []
+  }
+
+  // separate each title
+  return s.split(';').map(parseTitleGrep)
 }
 
 /**
@@ -120,6 +132,7 @@ function parseGrep(titlePart, tags) {
 module.exports = {
   parseGrep,
   parseTitleGrep,
+  parseFullTitleGrep,
   parseTagsGrep,
   shouldTestRun,
   shouldTestRunTags,

--- a/src/utils.js
+++ b/src/utils.js
@@ -101,11 +101,27 @@ function shouldTestRunTitle(parsedGrep, testName) {
     return true
   }
 
-  if (parsedGrep.invert) {
-    return !testName.includes(parsedGrep.title)
+  if (!Array.isArray(parsedGrep)) {
+    console.error('Invalid parsed title grep')
+    console.error(parsedGrep)
+    throw new Error('Expected title grep to be an array')
   }
 
-  return testName.includes(parsedGrep.title)
+  if (!parsedGrep.length) {
+    return true
+  }
+
+  // TODO if some titles greps are "invert: true" we should
+  // use AND instead of OR, otherwise it does the
+  // opposite of what we probably want to do
+
+  return parsedGrep.some((titleGrep) => {
+    if (titleGrep.invert) {
+      return !testName.includes(titleGrep.title)
+    }
+
+    return testName.includes(titleGrep.title)
+  })
 }
 
 // note: tags take precedence over the test name
@@ -124,7 +140,7 @@ function shouldTestRun(parsedGrep, testName, tags = []) {
 
 function parseGrep(titlePart, tags) {
   return {
-    title: parseTitleGrep(titlePart),
+    title: parseFullTitleGrep(titlePart),
     tags: parseTagsGrep(tags),
   }
 }


### PR DESCRIPTION
- closes #40 

You can pass multiple title substrings to match separating them with `;` character. Each substring is trimmed.

```shell
# run all tests with "hello world" or "auth user" in their title
$ npx cypress run --env grep="hello world; auth user"
```