### PR TITLE
feat: support suite tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,22 @@ jobs:
             --env grepTags=@smoke \
             --expect expects/describe-tags-spec.json
 
+      - name: Nested describes with grep 🧪
+        run: |
+          npx cypress-expect \
+            --spec cypress/integration/nested-describe-spec.js \
+            --config testFiles="nested-describe-spec.js" \
+            --env grepTags=@smoke \
+            --expect expects/nested-describe-spec.json
+
+      - name: Nested describes without grep 🧪
+        run: |
+          npx cypress-expect \
+            --spec cypress/integration/nested-describe-spec.js \
+            --config testFiles="nested-describe-spec.js" \
+            --env grepTags=@does-not-exist \
+            --pending 1
+
       # repeat the selected test 3 times
       - name: Burn grepped test 🧪
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,6 @@ jobs:
             --expect expects/describe-tags-invert-spec.json
 
       # enable suite of tests using a tag
-      # DOES NOT WORK YET
       - name: Enable suite of tests with a tag 🧪
         run: |
           npx cypress-expect \

--- a/README.md
+++ b/README.md
@@ -193,16 +193,19 @@ This package comes with [src/index.d.ts](./src/index.d.ts) definition file that 
 
 ## Test suites
 
-The tags are also applied to the "describe" blocks with some limitations:
-
-- you can only use the config object tags
+The tags are also applied to the "describe" blocks. In that case, the tests look up if any of their outer suites are enabled.
 
 ```js
 describe('block with config tag', { tags: '@smoke' }, () => {
 })
 ```
 
-- currently only the invert tag to skip the blog has meaningful effect. For example you can skip the above suite of tests by using `--env grepTags=-@smoke` value. Keep an eye on issue [#22](https://github.com/bahmutov/cypress-grep/issues/22) for the full support implementation.
+```
+# run any tests in the blocks having "@smoke" tag
+--env grepTags=@smoke
+# skip any blocks with "@smoke" tag
+--env grepTags=-@smoke
+```
 
 See the [cypress/integration/describe-tags-spec.js](./cypress/integration/describe-tags-spec.js) file.
 

--- a/cypress/integration/describe-tags-spec.js
+++ b/cypress/integration/describe-tags-spec.js
@@ -8,10 +8,6 @@ describe('block with no tags', () => {
   it('inside describe 2', () => {})
 })
 
-// WORKING: ignore the entire suite using invert option
-//  --env grepTags=-@smoke
-// NOT WORKING: run all the tests in this suite only
-//  --env grepTags=@smoke
 describe('block with tag smoke', { tags: '@smoke' }, () => {
   it('inside describe 3', () => {})
 

--- a/cypress/integration/nested-describe-spec.js
+++ b/cypress/integration/nested-describe-spec.js
@@ -1,0 +1,10 @@
+/// <reference path="../../src/index.d.ts" />
+
+// @ts-check
+describe('grand', () => {
+  describe('outer', { tags: '@smoke' }, () => {
+    describe('inner', () => {
+      it('runs', () => {})
+    })
+  })
+})

--- a/expects/describe-tags-spec.json
+++ b/expects/describe-tags-spec.json
@@ -4,8 +4,8 @@
     "inside describe 2": "pending"
   },
   "block with tag smoke": {
-    "inside describe 3": "pending",
-    "inside describe 4": "pending"
+    "inside describe 3": "passed",
+    "inside describe 4": "passed"
   },
   "block without any tags": {
     "test with tag smoke": "passed"

--- a/expects/nested-describe-spec.json
+++ b/expects/nested-describe-spec.json
@@ -1,0 +1,9 @@
+{
+  "grand": {
+    "outer": {
+      "inner": {
+        "runs": "passing"
+      }
+    }
+  }
+}


### PR DESCRIPTION
- closes #22

We look up the suite tags when deciding if we need to run a test. For this suite

```js
describe('grand', () => {
  describe('outer', { tags: '@smoke' }, () => {
    describe('inner', () => {
      it('runs', () => {})
    })
  })
})
```
We can run the test using `--env grepTags=@smoke`
